### PR TITLE
Fix mutation tests

### DIFF
--- a/src/oncoexporter/cda/cda_factory.py
+++ b/src/oncoexporter/cda/cda_factory.py
@@ -3,17 +3,13 @@ import platform
 import os
 
 import pandas as pd
-from .cda_downloader import CdaDownloader
+
 
 class CdaFactory(metaclass=abc.ABCMeta):
     """Superclass for the CDA Factory Classes
 
     Each subclass must implement the to_ga4gh method, which transforms a row of a table from CDA to a GA4GH Message.
     """
-    def __init__(self, overwrite_downloads:bool=False):
-        downloader = CdaDownloader()
-        downloader.download_if_needed(overwrite_downloads)
-        self._icdo_to_ncit_path = downloader.get_icdo_to_ncit_path()
 
     @abc.abstractmethod
     def to_ga4gh(self, row:pd.Series):

--- a/src/oncoexporter/cda/cda_mutation_factory.py
+++ b/src/oncoexporter/cda/cda_mutation_factory.py
@@ -69,6 +69,6 @@ class CdaMutationFactory(CdaFactory):
         mutation = OpMutation(Hugo_Symbol=Hugo_Symbol, Entrez_Gene_Id=Entrez_Gene_Id, NCBI_Build=NCBI_Build,
                               Chromosome=Chromosome, Start_Position=Start_Position, Reference_Allele=Reference_Allele,
                               Tumor_Seq_Allele2=Tumor_Seq_Allele2,
-                              HGVSc=HGVSc, HGVSp=HGVSp_Short, Transcript_ID=Transcript_ID, ENSP=ENSP)
+                              HGVSc=HGVSc, HGVSp_Short=HGVSp_Short, Transcript_ID=Transcript_ID, ENSP=ENSP)
         return mutation.to_ga4gh()
 

--- a/src/oncoexporter/cda/cda_mutation_factory.py
+++ b/src/oncoexporter/cda/cda_mutation_factory.py
@@ -1,6 +1,10 @@
 import pandas as pd
-from .cda_factory import CdaFactory
+import phenopackets as pp
+
 from oncoexporter.model.op_mutation import OpMutation
+
+from .cda_factory import CdaFactory
+
 
 class CdaMutationFactory(CdaFactory):
     """
@@ -44,7 +48,7 @@ class CdaMutationFactory(CdaFactory):
             'Mutation_Status', 'HGVSc', 'HGVSp', 'HGVSp_Short', 'Transcript_ID', 'ENSP'
         ]
 
-    def to_ga4gh(self, row):
+    def to_ga4gh(self, row) -> pp.VariationDescriptor:
         """
         convert a row from the CDA mutation table into an
         Individual message (GA4GH Phenopacket Schema)
@@ -52,7 +56,7 @@ class CdaMutationFactory(CdaFactory):
 
        :param row: a row from the CDA subject table
         """
-        if not isinstance(row, pd.core.series.Series):
+        if not isinstance(row, pd.Series):
             raise ValueError(f"Invalid argument. Expected pandas series but got {type(row)}")
 
         cda_subject_id, primary_site, Hugo_Symbol, Entrez_Gene_Id, NCBI_Build, Chromosome, \
@@ -62,7 +66,9 @@ class CdaMutationFactory(CdaFactory):
         Mutation_Status, HGVSc, HGVSp, HGVSp_Short, Transcript_ID, ENSP \
             = self.get_items_from_row(row, self._column_names)
 
-        mutation = OpMutation(Hugo_Symbol=Hugo_Symbol, Entrez_Gene_Id=Entrez_Gene_Id,
-                            HGVSc=HGVSc, HGVSp=HGVSp_Short, Transcript_ID=Transcript_ID, ENSP=ENSP)
+        mutation = OpMutation(Hugo_Symbol=Hugo_Symbol, Entrez_Gene_Id=Entrez_Gene_Id, NCBI_Build=NCBI_Build,
+                              Chromosome=Chromosome, Start_Position=Start_Position, Reference_Allele=Reference_Allele,
+                              Tumor_Seq_Allele2=Tumor_Seq_Allele2,
+                              HGVSc=HGVSc, HGVSp=HGVSp_Short, Transcript_ID=Transcript_ID, ENSP=ENSP)
         return mutation.to_ga4gh()
 

--- a/src/oncoexporter/model/op_mutation.py
+++ b/src/oncoexporter/model/op_mutation.py
@@ -23,7 +23,7 @@ class OpMutation(OpMessage):
             self._alt = Tumor_Seq_Allele2
             self._mutation_status = Mutation_Status
 
-    def to_ga4gh(self, acmg=None):
+    def to_ga4gh(self) -> PPkt.VariationDescriptor:
         """
         Transform this Variant object into a "variantInterpretation" message of the GA4GH Phenopacket schema
         """

--- a/tests/test_op_mutation.py
+++ b/tests/test_op_mutation.py
@@ -1,12 +1,10 @@
-import pandas as pd
-from unittest import TestCase
-import phenopackets as PPkt
 import os
-from oncoexporter.model import OpMutation
-from oncoexporter.cda import CdaMutationFactory
-## REMOVE LATER
-from google.protobuf.json_format import MessageToJson
 
+import pandas as pd
+import phenopackets as PPkt
+import pytest
+
+from oncoexporter.cda import CdaMutationFactory
 
 TESTDATA_FILENAME = os.path.join(os.path.dirname(__file__), 'data', 'mutation_excerpt.tsv')
 
@@ -40,67 +38,61 @@ def get_vcf_ref(vinterpretation):
     return genome_assembly, ref, alt, pos
 
 
-class OpMutationTestCase(TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
+class TestOpMutation:
+
+    @pytest.fixture
+    def mutation_factory(self) -> CdaMutationFactory:
+        return CdaMutationFactory()
+
+    @pytest.fixture
+    def a1mi(self) -> pd.Series:
         df = pd.read_csv(TESTDATA_FILENAME, sep="\t")
         # TCGA.TCGA-C5-A1MI -- subject is on the first row
         df_a1mi = df[df['cda_subject_id'].str.contains("TCGA.TCGA-C5-A1MI")]
         assert len(df_a1mi) == 1
-        cls._a1mi = df_a1mi.iloc[0]
+        return df_a1mi.iloc[0]
 
-
-
-    def test_a1mi(self):
-        factory = CdaMutationFactory()
-        vinterpretation = factory.to_ga4gh(self._a1mi)
-        self.assertIsNotNone(vinterpretation)
+    def test_a1mi(self, mutation_factory: CdaMutationFactory,
+                  a1mi: pd.Series):
+        vinterpretation = mutation_factory.to_ga4gh(a1mi)
+        assert vinterpretation is not None
         genome_assembly, ref, alt, pos = get_vcf_ref(vinterpretation=vinterpretation)
-        self.assertEqual("hg38", genome_assembly)
+        assert genome_assembly == "GRCh38"
 
-
-
-    def test_gene(self):
+    def test_gene(self, mutation_factory: CdaMutationFactory):
         d = get_column_dict()
         d['Hugo_Symbol'] = "MFG42"
         d['Entrez_Gene_Id'] = "42"
         series = pd.Series(d)
-        factory = CdaMutationFactory()
-        vinterpretation = factory.to_ga4gh(series)
-        self.assertIsNotNone(vinterpretation)
-        self.assertIsNotNone(vinterpretation.variation_descriptor)
-        vdescriptor = vinterpretation.variation_descriptor
-        self.assertIsNotNone(vdescriptor)
-        self.assertIsNotNone(vdescriptor.gene_context)
-        gcontext = vdescriptor.gene_context
-        self.assertEqual("NCBIGene:42", gcontext.value_id)
-        self.assertEqual("MFG42", gcontext.symbol)
-        json_string = MessageToJson(vinterpretation)
-        print(json_string)
 
-    def test_hgvs(self):
+        vinterpretation = mutation_factory.to_ga4gh(series)
+        assert vinterpretation is not None
+        assert vinterpretation.variation_descriptor is not None
+
+        vdescriptor = vinterpretation.variation_descriptor
+        assert vdescriptor is not None
+        assert vdescriptor.gene_context is not None
+
+        gcontext = vdescriptor.gene_context
+        assert gcontext.value_id == "NCBIGene:42"
+        assert gcontext.symbol == "MFG42"
+
+    def test_hgvs(self, mutation_factory: CdaMutationFactory):
         d = get_column_dict()
         d['Transcript_ID'] = "ENST00000380152"
         d['ENSP'] = "ENSP00000369497"
         d['HGVSc'] = "c.5526T>G"
         d['HGVSp'] = "p.Tyr1842Ter"
         series = pd.Series(d)
-        factory = CdaMutationFactory()
-        vinterpretation = factory.to_ga4gh(series)
 
-        self.assertIsNotNone(vinterpretation)
-        self.assertIsNotNone(vinterpretation.variation_descriptor)
-        self.assertEqual(2, len(vinterpretation.variation_descriptor.expressions))
+        vinterpretation = mutation_factory.to_ga4gh(series)
 
-        self.assertEqual("hgvs.c", vinterpretation.variation_descriptor.expressions[0].syntax)
-        self.assertEqual("ENST00000380152:c.5526T>G", vinterpretation.variation_descriptor.expressions[0].value)
+        assert vinterpretation is not None
+        assert vinterpretation.variation_descriptor is not None
+        assert len(vinterpretation.variation_descriptor.expressions) == 2
 
-        self.assertEqual("hgvs.p", vinterpretation.variation_descriptor.expressions[1].syntax)
-        self.assertEqual("ENSP00000369497:p.Tyr1842Ter", vinterpretation.variation_descriptor.expressions[1].value)
+        assert vinterpretation.variation_descriptor.expressions[0].syntax == "hgvs.c"
+        assert vinterpretation.variation_descriptor.expressions[0].value == "ENST00000380152:c.5526T>G"
 
-
-
-
-
-
-
+        assert vinterpretation.variation_descriptor.expressions[1].syntax == "hgvs.p"
+        assert vinterpretation.variation_descriptor.expressions[1].value == "ENSP00000369497:p.Tyr1842Ter"


### PR DESCRIPTION
@justaddcoffee I am proposing changes to the mutation tests to make them pass.

The issue with the code was that the functions `test_gene` and `test_hgvs` did not include all required fields. I changed the test inputs such that the info is present and the tests only update the tested fields, such as `Hugo_Symbol` and `HGVSc`.

Some tests fail even after this PR, but we need to resolve those separately.

---

Pls let me know if the changes correspond to what you intended to test back in the September..