### PR TITLE
Work on mutation ETL

### DIFF
--- a/src/oncoexporter/cda/cda_factory.py
+++ b/src/oncoexporter/cda/cda_factory.py
@@ -56,7 +56,7 @@ class CdaFactory(metaclass=abc.ABCMeta):
         if isinstance(days, float) and not math.isnan(days):
             days = int(days) # this is because some values are like 73.0
         if not isinstance(days, int):
-            raise ValueError(f"days argument ({days}) must be int or str but was {type(days)}"
+            raise ValueError(f"days argument ({days}) must be int or str but was {type(days)}")
 
     def get_local_share_directory(self, local_dir=None):
         my_platform = platform.platform()

--- a/src/oncoexporter/cda/cda_mutation_factory.py
+++ b/src/oncoexporter/cda/cda_mutation_factory.py
@@ -1,7 +1,7 @@
+import math
+
 import pandas as pd
 import phenopackets as pp
-
-from oncoexporter.model.op_mutation import OpMutation
 
 from .cda_factory import CdaFactory
 
@@ -11,44 +11,39 @@ class CdaMutationFactory(CdaFactory):
     https://cda.readthedocs.io/en/latest/Schema/fields_mutation/
     153 fields - need to decide which to keep
 
-    cda_subject_id
-    primary_site
-    Hugo_Symbol
-    Entrez_Gene_Id
-    NCBI_Build
-    Chromosome
-    Start_Position
-    End_Position
-    Reference_Allele
-    Tumor_Seq_Allele1
-    Tumor_Seq_Allele2
-    dbSNP_RS
-    dbSNP_Val_Status
-    Match_Norm_Seq_Allele1
-    Match_Norm_Seq_Allele2
-    Tumor_Validation_Allele1
-    Tumor_Validation_Allele2
-    Match_Norm_Validation_Allele1
-    Match_Norm_Validation_Allele2
-    Mutation_Status
-    HGVSc
-    HGVSp
-    HGVSp_Short
-    Transcript_ID
-    ENSP
-
+    'Entrez_Gene_Id',
+    'Hugo_Symbol',
+    'NCBI_Build',
+    'Chromosome',
+    'Start_Position',
+    'Reference_Allele',
+    'Tumor_Seq_Allele2',
+    'dbSNP_RS',
+    'Transcript_ID',
+    'HGVSc',
+    'ENSP',
+    'HGVSp_Short',
+    'Mutation_Status',
+    't_depth',
+    't_ref_count',
+    't_alt_count',
+    'n_depth',
+    'n_ref_count',
+    'n_alt_count',
     """
 
     def __init__(self):
         self._column_names = [
-            'cda_subject_id', 'primary_site', 'Hugo_Symbol', 'Entrez_Gene_Id', 'NCBI_Build', 'Chromosome',
-            'Start_Position', 'End_Position', 'Reference_Allele', 'Tumor_Seq_Allele1', 'Tumor_Seq_Allele2', 'dbSNP_RS',
-            'dbSNP_Val_Status', 'Match_Norm_Seq_Allele1', 'Match_Norm_Seq_Allele2', 'Tumor_Validation_Allele1',
-            'Tumor_Validation_Allele2', 'Match_Norm_Validation_Allele1', 'Match_Norm_Validation_Allele2',
-            'Mutation_Status', 'HGVSc', 'HGVSp', 'HGVSp_Short', 'Transcript_ID', 'ENSP'
+            'Entrez_Gene_Id', 'Hugo_Symbol',
+            'NCBI_Build', 'Chromosome', 'Start_Position', 'Reference_Allele', 'Tumor_Seq_Allele2',
+            'dbSNP_RS',
+            'Transcript_ID', 'HGVSc', 'ENSP', 'HGVSp_Short',
+            'Mutation_Status',
+            't_depth', 't_ref_count', 't_alt_count',
+            'n_depth', 'n_ref_count', 'n_alt_count'
         ]
 
-    def to_ga4gh(self, row) -> pp.VariationDescriptor:
+    def to_ga4gh(self, row: pd.Series) -> pp.VariantInterpretation:
         """
         convert a row from the CDA mutation table into an
         Individual message (GA4GH Phenopacket Schema)
@@ -59,16 +54,76 @@ class CdaMutationFactory(CdaFactory):
         if not isinstance(row, pd.Series):
             raise ValueError(f"Invalid argument. Expected pandas series but got {type(row)}")
 
-        cda_subject_id, primary_site, Hugo_Symbol, Entrez_Gene_Id, NCBI_Build, Chromosome, \
-        Start_Position, End_Position, Reference_Allele, Tumor_Seq_Allele1, Tumor_Seq_Allele2, dbSNP_RS, \
-        dbSNP_Val_Status, Match_Norm_Seq_Allele1, Match_Norm_Seq_Allele2, Tumor_Validation_Allele1, \
-        Tumor_Validation_Allele2, Match_Norm_Validation_Allele1, Match_Norm_Validation_Allele2, \
-        Mutation_Status, HGVSc, HGVSp, HGVSp_Short, Transcript_ID, ENSP \
-            = self.get_items_from_row(row, self._column_names)
+        if any(field not in row for field in self._column_names):
+            keys = set(row.index)
+            missing = keys.difference(self._column_names)
+            raise ValueError(f'Missing field(s): {missing}')
 
-        mutation = OpMutation(Hugo_Symbol=Hugo_Symbol, Entrez_Gene_Id=Entrez_Gene_Id, NCBI_Build=NCBI_Build,
-                              Chromosome=Chromosome, Start_Position=Start_Position, Reference_Allele=Reference_Allele,
-                              Tumor_Seq_Allele2=Tumor_Seq_Allele2,
-                              HGVSc=HGVSc, HGVSp_Short=HGVSp_Short, Transcript_ID=Transcript_ID, ENSP=ENSP)
-        return mutation.to_ga4gh()
+
+        vdescriptor = pp.VariationDescriptor()
+
+        vdescriptor.id = self._generate_id(row)
+
+        # Gene context
+        if row['Hugo_Symbol'] is not None and row['Entrez_Gene_Id'] is not None:
+            vdescriptor.gene_context.value_id = f"NCBIGene:{row['Entrez_Gene_Id']}"
+            vdescriptor.gene_context.symbol = row['Hugo_Symbol']
+
+        # We may consider including an HGVS c expression for ALL transcripts,
+        # using the `all_effects` field that looks like this:
+        # SPRY3,missense_variant,p.G118A,ENST00000302805,NM_005840.2,c.353G>C,MODERATE,YES,deleterious(0),benign(0.001),1;SPRY3,missense_variant,p.G118A,ENST00000675360,NM_001304990.1,c.353G>C,MODERATE,,deleterious(0),benign(0.001),1
+        if row['Transcript_ID'] is not None and row['HGVSc'] is not None:
+            hgvs_expression = pp.Expression()
+            hgvs_expression.syntax = "hgvs.c"
+            hgvs_expression.value = f"{row['Transcript_ID']}:{row['HGVSc']}"
+            vdescriptor.expressions.append(hgvs_expression)
+
+        if row['ENSP'] is not None and row['HGVSp_Short'] is not None:
+            hgvs_expression = pp.Expression()
+            hgvs_expression.syntax = "hgvs.p"
+            hgvs_expression.value = f"{row['ENSP']}:{row['HGVSp_Short']}"
+            vdescriptor.expressions.append(hgvs_expression)
+
+        # TODO: consider adding HGVS.g
+
+        vdescriptor.vcf_record.CopyFrom(self._create_vcf_record(row))
+
+        # Tumor/normal depths
+        for name in ('t_depth', 't_ref_count', 't_alt_count',
+                     'n_depth', 'n_ref_count', 'n_alt_count'):
+            val = row[name]
+            ext = pp.Extension()
+            ext.name = name
+            # We expect an `int` or `None`.
+            ext.value = str(val)
+            vdescriptor.extensions.append(ext)
+
+        # Mutation status
+        ms = row['Mutation_Status']
+        if ms is not None and len(ms) > 1:
+            ext = pp.Extension()
+            ext.name = 'Mutation_Status'
+            ext.value = ms
+            vdescriptor.extensions.append(ext)
+
+        vdescriptor.molecule_context = pp.MoleculeContext.genomic
+
+        vinterpretation = pp.VariantInterpretation()
+        vinterpretation.variation_descriptor.CopyFrom(vdescriptor)
+        return vinterpretation
+
+    @staticmethod
+    def _create_vcf_record(row: pd.Series) -> pp.VcfRecord:
+        vcf_record = pp.VcfRecord()
+        vcf_record.genome_assembly = row['NCBI_Build']
+        vcf_record.chrom = row['Chromosome']
+        vcf_record.id = row['dbSNP_RS']
+        vcf_record.pos = row['Start_Position']
+        vcf_record.ref = row['Reference_Allele']
+        vcf_record.alt = row['Tumor_Seq_Allele2']
+        return vcf_record
+
+    @staticmethod
+    def _generate_id(row: pd.Series) -> str:
+        return str(hash(''.join(str(x) for x in row.values)))
 

--- a/src/oncoexporter/cda/cda_mutation_factory.py
+++ b/src/oncoexporter/cda/cda_mutation_factory.py
@@ -47,11 +47,10 @@ class CdaMutationFactory(CdaFactory):
 
     def to_ga4gh(self, row: pd.Series) -> pp.VariantInterpretation:
         """
-        convert a row from the CDA mutation table into an
-        Individual message (GA4GH Phenopacket Schema)
-        The row is a pd.core.series.Series and contains the columns
+        Convert a row from the CDA mutation table
+        into a VariantInterpretation message (GA4GH Phenopacket Schema).
 
-       :param row: a row from the CDA subject table
+       :param row: a :class:`pd.Series` with the row of the CDA mutation table.
         """
         if not isinstance(row, pd.Series):
             raise ValueError(f"Invalid argument. Expected pandas series but got {type(row)}")

--- a/src/oncoexporter/cda/cda_table_importer.py
+++ b/src/oncoexporter/cda/cda_table_importer.py
@@ -140,11 +140,11 @@ class CdaTableImporter(CdaImporter[Q]):
         ppackt_d = {}
 
         # First obtain the pandas DataFrames from the CDA tables with rows that correspond to the Query
-        subject_df = self._get_subject_df(source)
-        merged_df = self.get_merged_diagnosis_research_subject_df(source)
-        specimen_df = self.get_specimen_df(source)
-        treatment_df = self.get_treatment_df(source)
-        mutation_df = self.get_mutation_df(source)
+        subject_df = self._get_subject_df(source, cohort_name)
+        merged_df = self.get_merged_diagnosis_research_subject_df(source, cohort_name)
+        specimen_df = self.get_specimen_df(source, cohort_name)
+        treatment_df = self.get_treatment_df(source, cohort_name)
+        mutation_df = self.get_mutation_df(source, cohort_name)
 
         # Now use the CdaFactory classes to transform the information from the DataFrames into
         # components of the GA4GH Phenopacket Schema

--- a/src/oncoexporter/model/op_mutation.py
+++ b/src/oncoexporter/model/op_mutation.py
@@ -23,7 +23,7 @@ class OpMutation(OpMessage):
             self._alt = Tumor_Seq_Allele2
             self._mutation_status = Mutation_Status
 
-    def to_ga4gh(self) -> PPkt.VariationDescriptor:
+    def to_ga4gh(self) -> PPkt.VariantInterpretation:
         """
         Transform this Variant object into a "variantInterpretation" message of the GA4GH Phenopacket schema
         """
@@ -59,6 +59,7 @@ class OpMutation(OpMessage):
         vcf_record.ref = self._ref
         vcf_record.alt = self._alt
         vdescriptor.vcf_record.CopyFrom(vcf_record)
+
         vinterpretation = PPkt.VariantInterpretation()
         vinterpretation.variation_descriptor.CopyFrom(vdescriptor)
         return vinterpretation


### PR DESCRIPTION
Enhance ETL of the mutation table into Phenopacket Schema's `VariantInterpretation` elements in `CdaMutationFactory`.

The PR includes several changes:
- add few more checks to the previously used `VariantInterpretation` fields
- do not include an HGVS expression if transcript ID is missing to prevent ambiguity/inconsistency
- do not create a VCF record for ref/mut alleles that include dashes `-` (see #72 )
- create an `VariationDescriptor.id` by hashing all row fields
- store tumor/normal read counts in extensions
- store mutation status in an extension