### PR TITLE
Pull mutation data from GDC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "phenopackets>=2.0.2",
     "requests>=2.25.0,<3.0",
     "cdapython@git+https://github.com/CancerDataAggregator/cda-python",
+    "ipython<=8.22.2",  # higher versions result in an import error
     "tqdm>=4.60",
 ]
 [project.optional-dependencies]

--- a/src/oncoexporter/cda/__init__.py
+++ b/src/oncoexporter/cda/__init__.py
@@ -6,10 +6,11 @@ from .cda_individual_factory import CdaIndividualFactory
 from .cda_mutation_factory import CdaMutationFactory
 from .cda_table_importer import CdaTableImporter
 from .cda_medicalaction_factory import make_cda_medicalaction
-
+from ._gdc import GdcMutationService
 
 __all__ = [
     "CdaFactory",
     "CdaDiseaseFactory", "CdaIndividualFactory", "CdaBiosampleFactory", "CdaMutationFactory",
     "CdaTableImporter", "make_cda_medicalaction", "configure_cda_table_importer",
+    'GdcMutationService',
 ]

--- a/src/oncoexporter/cda/_gdc.py
+++ b/src/oncoexporter/cda/_gdc.py
@@ -1,0 +1,127 @@
+import json
+import logging
+import typing
+
+import phenopackets as pp
+import requests
+
+
+class GdcMutationService:
+    """
+    `GdcMutationService` queries Genomic Data Commons REST endpoint to fetch variants for a CDA subject.
+    """
+
+    def __init__(
+            self,
+            page_size=100,
+            page=1,
+            timeout=10,
+    ):
+        self._logger = logging.getLogger(__name__)
+        self._url = 'https://api.gdc.cancer.gov/ssms'
+        self._page_size = page_size
+        self._page = page
+        self._timeout = timeout
+        self._fields = ','.join((
+            # "mutation_type",
+            # "mutation_subtype",
+            "ncbi_build",
+            "chromosome",
+            "start_position",
+            # "end_position",
+            "reference_allele",
+            "tumor_allele",
+            # "genomic_dna_change",
+            # "end_position",
+            # "gene_aa_change",
+            "consequence.transcript.gene.gene_id",
+            "consequence.transcript.gene.symbol",
+            "consequence.transcript.transcript_id",
+            "consequence.transcript.annotation.hgvsc",
+        ))
+
+    def fetch_variants(self, subject_id: str) -> typing.Sequence[pp.VariantInterpretation]:
+        params = self._prepare_query_params(subject_id)
+
+        response = requests.get(self._url, params=params, timeout=self._timeout)
+
+        if response.status_code == 200:
+            data = response.json()
+            mutations = data.get("data", {}).get("hits", [])
+
+            mutation_details = []
+            for mutation in mutations:
+                vi = self._map_mutation_to_variant_interpretation(mutation)
+                mutation_details.append(vi)
+
+            return mutation_details
+        else:
+            raise ValueError(f'Failed to fetch data due to {response.status_code}: {response.reason}')
+
+    def _prepare_query_params(self, subject_id: str):
+        filters = {
+            "op": "in",
+            "content": {
+                "field": "cases.case_id",
+                "value": [subject_id]
+            }
+        }
+        return {
+            "fields": self._fields,
+            "filters": json.dumps(filters),
+            "format": "JSON",
+            "size": self._page_size,
+            "from": (self._page - 1) * self._page_size + 1,
+        }
+
+    def _map_mutation_to_variant_interpretation(self, mutation) -> typing.Optional[pp.VariantInterpretation]:
+        vcf_record = self._parse_vcf_record(mutation)
+
+        vd = pp.VariationDescriptor()
+        if vcf_record is not None:
+            vd.vcf_record.CopyFrom(vcf_record)
+
+        # TODO: set gene
+        # TODO: 't_depth', 't_ref_count', 't_alt_count', 'n_depth', 'n_ref_count', 'n_alt_count'
+        # TODO: mutation status
+
+        for csq in mutation['consequence']:
+            expression = GdcMutationService._map_consequence_to_expression(csq)
+            if expression is not None:
+                vd.expressions.append(expression)
+
+        vd.molecule_context = pp.MoleculeContext.genomic
+
+        vi = pp.VariantInterpretation()
+        vi.variation_descriptor.CopyFrom(vd)
+        return vi
+
+    def _parse_vcf_record(self, mutation) -> typing.Optional[pp.VcfRecord]:
+        if mutation['reference_allele'] == '-' or mutation['tumor_allele'] == '-':
+            self._logger.debug(
+                'Cannot create a VCF record due to missing bases in the reference_allele/tumor_allele alleles: %s',
+                mutation)
+            return None
+
+        vcf_record = pp.VcfRecord()
+
+        vcf_record.genome_assembly = mutation['ncbi_build']
+        vcf_record.chrom = mutation['chromosome']
+        vcf_record.id = mutation['id']
+        vcf_record.pos = mutation['start_position']
+        vcf_record.ref = mutation['reference_allele']
+        vcf_record.alt = mutation['tumor_allele']
+
+        return vcf_record
+
+    @staticmethod
+    def _map_consequence_to_expression(csq) -> typing.Optional[pp.Expression]:
+        tx = csq['transcript']
+
+        expression = pp.Expression()
+        expression.syntax = 'hgvs.c'
+        tx_id = tx['transcript_id']
+        ann = tx['annotation']['hgvsc']
+        expression.value = f'{tx_id}:{ann}'
+
+        return expression

--- a/src/oncoexporter/cda/_gdc.py
+++ b/src/oncoexporter/cda/_gdc.py
@@ -78,6 +78,7 @@ class GdcMutationService:
         vcf_record = self._parse_vcf_record(mutation)
 
         vd = pp.VariationDescriptor()
+        vd.id = mutation['id']
         if vcf_record is not None:
             vd.vcf_record.CopyFrom(vcf_record)
 

--- a/src/oncoexporter/cda/cda_table_importer.py
+++ b/src/oncoexporter/cda/cda_table_importer.py
@@ -38,6 +38,7 @@ class CdaTableImporter(CdaImporter[Q]):
                  use_cache: bool = False,
                  cache_dir: typing.Optional[str] = None,
                  page_size: int = 10000,
+                 gdc_timeout: int = 100_000,
                  ):
         self._use_cache = use_cache
         self._page_size = page_size
@@ -46,7 +47,7 @@ class CdaTableImporter(CdaImporter[Q]):
         self._disease_factory = disease_factory
         self._specimen_factory = CdaBiosampleFactory()
         self._mutation_factory = CdaMutationFactory()
-        self.gdc_mutation_service = GdcMutationService(timeout=100000)
+        self.gdc_mutation_service = GdcMutationService(timeout=gdc_timeout)
 
         if cache_dir is None:
             self._cache_dir = os.path.join(os.getcwd(), '.oncoexporter_cache')

--- a/src/oncoexporter/cda/cda_table_importer.py
+++ b/src/oncoexporter/cda/cda_table_importer.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 from cdapython import Q
 import phenopackets as PPkt
 import typing
@@ -47,7 +46,7 @@ class CdaTableImporter(CdaImporter[Q]):
         self._disease_factory = disease_factory
         self._specimen_factory = CdaBiosampleFactory()
         self._mutation_factory = CdaMutationFactory()
-        self.gdc_mutation_service = GdcMutationService(timeout=gdc_timeout)
+        self._gdc_mutation_service = GdcMutationService(timeout=gdc_timeout)
 
         if cache_dir is None:
             self._cache_dir = os.path.join(os.getcwd(), '.oncoexporter_cache')
@@ -218,8 +217,7 @@ class CdaTableImporter(CdaImporter[Q]):
             individual_id = row["subject_id"]
             for rsub_subj in row["subject_identifier"]:
                 if rsub_subj["system"] == "GDC":
-                    variant_interpretations = self.gdc_mutation_service.fetch_variants(rsub_subj["value"])
-                    # TODO: plug above variant_interpretations into the phenopacket
+                    variant_interpretations = self._gdc_mutation_service.fetch_variants(rsub_subj["value"])
 
                     if len(variant_interpretations) == 0:
                         continue

--- a/tests/test_gdc_mutation.py
+++ b/tests/test_gdc_mutation.py
@@ -1,0 +1,17 @@
+import pytest
+
+from oncoexporter.cda import GdcMutationService
+
+
+@pytest.mark.skip('Requires internet connection')
+class TestGdcMutationService:
+
+    @pytest.fixture
+    def gdc_mutation_service(self) -> GdcMutationService:
+        return GdcMutationService()
+
+    def test_fetch_variants(self, gdc_mutation_service: GdcMutationService):
+        # TODO: test more
+        subject_id = 'a8b1f6e7-2bcf-460d-b1c6-1792a9801119'
+        variants = gdc_mutation_service.fetch_variants(subject_id)
+        print(variants)


### PR DESCRIPTION
The PR creates `GdcMutationService` to retrieve variants of CDA subjects from GDC.

See the [test](https://github.com/monarch-initiative/oncoexporter/blob/fetch-mutations-from-gdc/tests/test_gdc_mutation.py) for example usage.

The logic is based on the gist written by @sujaypatil96 [here](https://gist.github.com/sujaypatil96/5659f766abeed7adf52fb6ce771e5552). 

**There are still some TODOs left.** The mapping of the VCF coordinates and functional annotations should be complete, however, we still may need to explore GDC to add the read depths, gene, and the mutation status.

When ready, we can use `GdcMutationService` e.g. within `CdaTableImporter`, to get the variants for the subjects.

#80 