### PR TITLE
Start using `GdcMutationService` and associated methods in `CdaTableImporter`

### DIFF
--- a/src/oncoexporter/cda/_gdc.py
+++ b/src/oncoexporter/cda/_gdc.py
@@ -62,7 +62,7 @@ class GdcMutationService:
         filters = {
             "op": "in",
             "content": {
-                "field": "cases.case_id",
+                "field": "cases.submitter_id",
                 "value": [subject_id]
             }
         }

--- a/src/oncoexporter/cda/_gdc.py
+++ b/src/oncoexporter/cda/_gdc.py
@@ -71,10 +71,9 @@ class GdcMutationService:
             "filters": json.dumps(filters),
             "format": "JSON",
             "size": self._page_size,
-            "from": (self._page - 1) * self._page_size + 1,
         }
 
-    def _map_mutation_to_variant_interpretation(self, mutation) -> typing.Optional[pp.VariantInterpretation]:
+    def _map_mutation_to_variant_interpretation(self, mutation) -> pp.VariantInterpretation:
         vcf_record = self._parse_vcf_record(mutation)
 
         vd = pp.VariationDescriptor()

--- a/tests/test_gdc_mutation.py
+++ b/tests/test_gdc_mutation.py
@@ -3,7 +3,7 @@ import pytest
 from oncoexporter.cda import GdcMutationService
 
 
-@pytest.mark.skip('Requires internet connection')
+# @pytest.mark.skip('Requires internet connection')
 class TestGdcMutationService:
 
     @pytest.fixture
@@ -12,6 +12,6 @@ class TestGdcMutationService:
 
     def test_fetch_variants(self, gdc_mutation_service: GdcMutationService):
         # TODO: test more
-        subject_id = 'a8b1f6e7-2bcf-460d-b1c6-1792a9801119'
-        variants = gdc_mutation_service.fetch_variants(subject_id)
-        print(variants)
+        submitter_id = 'TCGA-DX-A3UA'
+        variants = gdc_mutation_service.fetch_variants(submitter_id)
+        assert variants

--- a/tests/test_gdc_mutation.py
+++ b/tests/test_gdc_mutation.py
@@ -3,7 +3,7 @@ import pytest
 from oncoexporter.cda import GdcMutationService
 
 
-# @pytest.mark.skip('Requires internet connection')
+@pytest.mark.skip('Requires internet connection')
 class TestGdcMutationService:
 
     @pytest.fixture


### PR DESCRIPTION
This PR needs to be worked on and merged in before #81 

So far, we are successfully able to make and pull in [VariantInterpretation](https://phenopacket-schema.readthedocs.io/en/latest/variant-interpretation.html) objects that the GdcMutationService's `fetch_variants()` method is creating in CdaTableImporter.

TODOs on this PR:

- [x] Add `VariantInterpretation` to individual phenopacket